### PR TITLE
updated for node v20.11.0

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+2024.02.26 v0.2.2a
+- corrected some compatability issues allowing the code to be ran even with newer node versions
+
 2010.05.18, v0.2.1, 156141845042d0ac6d231823c311b2a1c7ffa86d
 - Added better error handling.
 - Added unique id to messages/events.

--- a/demo/chat.js
+++ b/demo/chat.js
@@ -1,36 +1,37 @@
 #!/usr/bin/env node
-var sys = require("sys"),
-	fs = require("fs"),
-	chat = require('../lib/server'),
-	router = require("../lib/router");
+var fs = require("fs"),
+    chat = require('../lib/server'),
+    router = require("../lib/router");
 
 // create chat server
 var chatServer = chat.createServer();
-chatServer.listen(8001);
+chatServer.listen(8001, function() {
+    console.log("Server is running on port 8001");
+});
 
 // create a channel and log all activity to stdout
 chatServer.addChannel({
-	basePath: "/chat"
+    basePath: "/chat"
 }).addListener("msg", function(msg) {
-	sys.puts("<" + msg.nick + "> " + msg.text);
+    console.log("<" + msg.nick + "> " + msg.text);
 }).addListener("join", function(msg) {
-	sys.puts(msg.nick + " join");
+    console.log(msg.nick + " join");
 }).addListener("part", function(msg) {
-	sys.puts(msg.nick + " part");
+    console.log(msg.nick + " part");
 });
 
 // server static web files
 function serveFiles(localDir, webDir) {
-	fs.readdirSync(localDir).forEach(function(file) {
-		var local = localDir + "/" + file,
-			web = webDir + "/" + file;
-		
-		if (fs.statSync(local).isDirectory()) {
-			serveFiles(local, web);
-		} else {
-			chatServer.passThru(web, router.staticHandler(local));
-		}
-	});
+    fs.readdirSync(localDir).forEach(function(file) {
+        var local = localDir + "/" + file,
+            web = webDir + "/" + file;
+
+        if (fs.statSync(local).isDirectory()) {
+            serveFiles(local, web);
+        } else {
+            chatServer.passThru(web, router.staticHandler(local));
+        }
+    });
 }
 serveFiles(__dirname + "/web", "");
 chatServer.passThru("/js/nodechat.js", router.staticHandler(__dirname + "/../web/nodechat.js"));

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -47,7 +47,7 @@ router.createServer = function() {
 	return {
 		listen: function(port, host) {
 			server.listen(port, host);
-			sys.puts("Server at http://" + (host || "127.0.0.1") + ":" + port.toString() + "/");
+			console.log("Server at http://" + (host || "127.0.0.1") + ":" + port.toString() + "/");
 		},
 		get: function(path, handler) {
 			getMap[path] = handler;
@@ -71,10 +71,10 @@ router.staticHandler = function (filename) {
       return;
     }
 
-    sys.puts("loading " + filename + "...");
+    console.log("loading " + filename + "...");
     readFile(filename, encoding, function (err, data) {
       if (err) {
-        sys.puts("Error loading " + filename);
+        console.log("Error loading " + filename);
       } else {
         body = data;
         headers = [ [ "Content-Type"   , content_type ]
@@ -82,7 +82,7 @@ router.staticHandler = function (filename) {
                   ];
           headers.push(["Cache-Control", "public"]);
          
-        sys.puts("static file " + filename + " loaded");
+        console.log("static file " + filename + " loaded");
         callback();
       }
     });


### PR DESCRIPTION
Changes Made:
In this pull request, I addressed the deprecated sys.puts usage by replacing it with console.log. This ensures compatibility with modern versions of Node.js and resolves the TypeError encountered in the code.

In index.js, I replaced sys.puts with console.log for logging server start-up messages.
In chat.js, I replaced sys.puts with console.log for logging chat messages, user joins, and user parts.

I've tested the modified code locally to ensure that the server starts up without errors and that chat messages, user joins, and user parts are logged correctly. 